### PR TITLE
Remove cloneflags

### DIFF
--- a/libcontainer/configs/config_unix.go
+++ b/libcontainer/configs/config_unix.go
@@ -16,6 +16,10 @@ func (c Config) HostUID() (int, error) {
 			return -1, fmt.Errorf("User namespaces enabled, but no root user mapping found.")
 		}
 		return id, nil
+	} else {
+		if c.UidMappings != nil {
+			return -1, fmt.Errorf("User mappings found, but user namespace is not enabled")
+		}
 	}
 	// Return default root uid 0
 	return 0, nil
@@ -33,6 +37,10 @@ func (c Config) HostGID() (int, error) {
 			return -1, fmt.Errorf("User namespaces enabled, but no root user mapping found.")
 		}
 		return id, nil
+	} else {
+		if c.GidMappings != nil {
+			return -1, fmt.Errorf("Gid mappings found, but user namespace is not enabled")
+		}
 	}
 	// Return default root uid 0
 	return 0, nil

--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -2,7 +2,11 @@
 
 package configs
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"sync"
+)
 
 const (
 	NEWNET  NamespaceType = "NEWNET"
@@ -12,6 +16,52 @@ const (
 	NEWIPC  NamespaceType = "NEWIPC"
 	NEWUSER NamespaceType = "NEWUSER"
 )
+
+var (
+	nsLock              sync.Mutex
+	supportedNamespaces = make(map[NamespaceType]bool)
+)
+
+// nsToFile converts the namespace type to its filename
+func nsToFile(ns NamespaceType) string {
+	switch ns {
+	case NEWNET:
+		return "net"
+	case NEWNS:
+		return "mnt"
+	case NEWPID:
+		return "pid"
+	case NEWIPC:
+		return "ipc"
+	case NEWUSER:
+		return "user"
+	case NEWUTS:
+		return "uts"
+	}
+	return ""
+}
+
+// IsNamespaceSupported returns the list of current kernel's supported
+// namespaces. The namespaces will be sorted in order that we can safely setns
+// to (i.e., mount namespace is at the bottom of the list)
+func IsNamespaceSupported(ns NamespaceType) bool {
+	nsLock.Lock()
+	defer nsLock.Unlock()
+	supported, ok := supportedNamespaces[ns]
+	if ok {
+		return supported
+	}
+	nsFile := nsToFile(ns)
+	// if the namespace type is unknown, just return false
+	if nsFile == "" {
+		return false
+	}
+	_, err := os.Stat(fmt.Sprintf("/proc/self/ns/%s", nsFile))
+	// a namespace is supported if it exists and we have permissions to read it
+	supported = err == nil
+	supportedNamespaces[ns] = supported
+	return supported
+}
 
 func NamespaceTypes() []NamespaceType {
 	return []NamespaceType{
@@ -35,26 +85,7 @@ func (n *Namespace) GetPath(pid int) string {
 	if n.Path != "" {
 		return n.Path
 	}
-	return fmt.Sprintf("/proc/%d/ns/%s", pid, n.file())
-}
-
-func (n *Namespace) file() string {
-	file := ""
-	switch n.Type {
-	case NEWNET:
-		file = "net"
-	case NEWNS:
-		file = "mnt"
-	case NEWPID:
-		file = "pid"
-	case NEWIPC:
-		file = "ipc"
-	case NEWUSER:
-		file = "user"
-	case NEWUTS:
-		file = "uts"
-	}
-	return file
+	return fmt.Sprintf("/proc/%d/ns/%s", pid, nsToFile(n.Type))
 }
 
 func (n *Namespaces) Remove(t NamespaceType) bool {

--- a/libcontainer/configs/namespaces_unix.go
+++ b/libcontainer/configs/namespaces_unix.go
@@ -118,3 +118,11 @@ func (n *Namespaces) index(t NamespaceType) int {
 func (n *Namespaces) Contains(t NamespaceType) bool {
 	return n.index(t) != -1
 }
+
+func (n *Namespaces) PathOf(t NamespaceType) string {
+	i := n.index(t)
+	if i == -1 {
+		return ""
+	}
+	return (*n)[i].Path
+}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -185,7 +185,7 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 		}
 	}
 	if len(nsMaps) > 0 {
-		nsPaths, err := orderNamespacePaths(nsMaps)
+		nsPaths, err := c.orderNamespacePaths(nsMaps, true)
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 	if err != nil {
 		return nil, newSystemError(err)
 	}
-	nsPaths, err := orderNamespacePaths(state.NamespacePaths)
+	nsPaths, err := c.orderNamespacePaths(state.NamespacePaths, false)
 	if err != nil {
 		return nil, newSystemError(err)
 	}
@@ -820,18 +820,21 @@ func (c *linuxContainer) currentState() (*State, error) {
 
 // orderNamespacePaths sorts that namespace paths into a list of paths that we
 // can safely setns to.
-func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
+func (c *linuxContainer) orderNamespacePaths(namespaces map[configs.NamespaceType]string, doInit bool) ([]string, error) {
 	paths := []string{}
-	for _, nsType := range []configs.NamespaceType{
+	nsTypes := []configs.NamespaceType{
 		configs.NEWIPC,
 		configs.NEWUTS,
 		configs.NEWNET,
 		configs.NEWPID,
 		configs.NEWNS,
-		// user namespace must be the last one because we need enough privilege
-		// to setns
-		configs.NEWUSER,
-	} {
+	}
+	// For now, only join user namespace if this is an exec in process and the
+	// container supports user namespace
+	if !doInit && c.config.Namespaces.Contains(configs.NEWUSER) {
+		nsTypes = append(nsTypes, configs.NEWUSER)
+	}
+	for _, nsType := range nsTypes {
 		if p, ok := namespaces[nsType]; ok && p != "" {
 			// check if the requested namespace is supported
 			if !configs.IsNamespaceSupported(nsType) {

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -128,7 +128,7 @@ func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProces
 		return nil, newSystemError(err)
 	}
 	if !doInit {
-		return c.newSetnsProcess(p, cmd, parentPipe, childPipe), nil
+		return c.newSetnsProcess(p, cmd, parentPipe, childPipe)
 	}
 	return c.newInitProcess(p, cmd, parentPipe, childPipe)
 }
@@ -157,7 +157,6 @@ func (c *linuxContainer) commandTemplate(p *Process, childPipe *os.File) (*exec.
 }
 
 func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, childPipe *os.File) (*initProcess, error) {
-	t := "_LIBCONTAINER_INITTYPE=standard"
 	cloneFlags := c.config.Namespaces.CloneFlags()
 	if cloneFlags&syscall.CLONE_NEWUSER != 0 {
 		if err := c.addUidGidMappings(cmd.SysProcAttr); err != nil {
@@ -169,21 +168,60 @@ func (c *linuxContainer) newInitProcess(p *Process, cmd *exec.Cmd, parentPipe, c
 			cmd.SysProcAttr.Credential = &syscall.Credential{}
 		}
 	}
-	cmd.Env = append(cmd.Env, t)
 	cmd.SysProcAttr.Cloneflags = cloneFlags
+
+	// set init process environment
+	env := []string{"_LIBCONTAINER_INITTYPE=standard"}
+	var joinNamespaces configs.Namespaces
+	var doClone bool
+	nsMaps := make(map[configs.NamespaceType]string)
+	for _, ns := range c.config.Namespaces {
+		if ns.Path != "" {
+			nsMaps[ns.Type] = ns.Path
+			joinNamespaces = append(joinNamespaces, ns)
+			if ns.Type == configs.NEWPID {
+				doClone = true
+			}
+		}
+	}
+	if len(nsMaps) > 0 {
+		nsPaths, err := orderNamespacePaths(nsMaps)
+		if err != nil {
+			return nil, err
+		}
+		env = append(env, fmt.Sprintf("_LIBCONTAINER_NSPATH=%s",
+			strings.Join(nsPaths, ",")))
+	}
+	if doClone {
+		env = append(env, "_LIBCONTAINER_DOCLONE=true")
+	}
+	cmd.Env = append(cmd.Env, env...)
+
 	return &initProcess{
-		cmd:        cmd,
-		childPipe:  childPipe,
-		parentPipe: parentPipe,
-		manager:    c.cgroupManager,
-		config:     c.newInitConfig(p),
+		cmd:            cmd,
+		childPipe:      childPipe,
+		parentPipe:     parentPipe,
+		manager:        c.cgroupManager,
+		config:         c.newInitConfig(p),
+		joinNamespaces: joinNamespaces,
+		doClone:        doClone,
 	}, nil
 }
 
-func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, childPipe *os.File) *setnsProcess {
+func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, childPipe *os.File) (*setnsProcess, error) {
+	state, err := c.currentState()
+	if err != nil {
+		return nil, newSystemError(err)
+	}
+	nsPaths, err := orderNamespacePaths(state.NamespacePaths)
+	if err != nil {
+		return nil, newSystemError(err)
+	}
 	cmd.Env = append(cmd.Env,
-		fmt.Sprintf("_LIBCONTAINER_INITPID=%d", c.initProcess.pid()),
+		fmt.Sprintf("_LIBCONTAINER_NSPATH=%s", strings.Join(nsPaths, ",")),
 		"_LIBCONTAINER_INITTYPE=setns",
+		"_LIBCONTAINER_DOCLONE=true",
+		"_LIBCONTAINER_SETSID=true",
 	)
 	if p.consolePath != "" {
 		cmd.Env = append(cmd.Env, "_LIBCONTAINER_CONSOLE_PATH="+p.consolePath)
@@ -195,7 +233,7 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 		childPipe:   childPipe,
 		parentPipe:  parentPipe,
 		config:      c.newInitConfig(p),
-	}
+	}, nil
 }
 
 func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
@@ -778,4 +816,29 @@ func (c *linuxContainer) currentState() (*State, error) {
 		}
 	}
 	return state, nil
+}
+
+// orderNamespacePaths sorts that namespace paths into a list of paths that we
+// can safely setns to.
+func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
+	paths := []string{}
+	for _, nsType := range []configs.NamespaceType{
+		// TODO: enable configs.NEWUSER,
+		configs.NEWIPC,
+		configs.NEWUTS,
+		configs.NEWNET,
+		configs.NEWPID,
+		// mnt namespace must be the last one. After switching to mnt
+		// namespace, the old /proc will be inaccessible.
+		configs.NEWNS,
+	} {
+		if p, ok := namespaces[nsType]; ok && p != "" {
+			// only set to join this namespace if it exists
+			if _, err := os.Lstat(p); err != nil {
+				return nil, newSystemError(err)
+			}
+			paths = append(paths, p)
+		}
+	}
+	return paths, nil
 }

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -833,9 +833,18 @@ func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string,
 		configs.NEWNS,
 	} {
 		if p, ok := namespaces[nsType]; ok && p != "" {
+			// check if the requested namespace is supported
+			if !configs.IsNamespaceSupported(nsType) {
+				return nil, newSystemError(fmt.Errorf("namespace %s is not supported", nsType))
+			}
 			// only set to join this namespace if it exists
 			if _, err := os.Lstat(p); err != nil {
 				return nil, newSystemError(err)
+			}
+			// do not allow namespace path with comma as we use it to separate
+			// the namespace paths
+			if strings.ContainsRune(p, ',') {
+				return nil, newSystemError(fmt.Errorf("invalid path %s", p))
 			}
 			paths = append(paths, p)
 		}

--- a/libcontainer/container_linux.go
+++ b/libcontainer/container_linux.go
@@ -823,14 +823,14 @@ func (c *linuxContainer) currentState() (*State, error) {
 func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
 	paths := []string{}
 	for _, nsType := range []configs.NamespaceType{
-		// TODO: enable configs.NEWUSER,
 		configs.NEWIPC,
 		configs.NEWUTS,
 		configs.NEWNET,
 		configs.NEWPID,
-		// mnt namespace must be the last one. After switching to mnt
-		// namespace, the old /proc will be inaccessible.
 		configs.NEWNS,
+		// user namespace must be the last one because we need enough privilege
+		// to setns
+		configs.NEWUSER,
 	} {
 		if p, ok := namespaces[nsType]; ok && p != "" {
 			// check if the requested namespace is supported

--- a/libcontainer/init_linux.go
+++ b/libcontainer/init_linux.go
@@ -138,25 +138,6 @@ func finalizeNamespace(config *initConfig) error {
 	return nil
 }
 
-// joinExistingNamespaces gets all the namespace paths specified for the container and
-// does a setns on the namespace fd so that the current process joins the namespace.
-func joinExistingNamespaces(namespaces []configs.Namespace) error {
-	for _, ns := range namespaces {
-		if ns.Path != "" {
-			f, err := os.OpenFile(ns.Path, os.O_RDONLY, 0)
-			if err != nil {
-				return err
-			}
-			err = system.Setns(f.Fd(), uintptr(ns.Syscall()))
-			f.Close()
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // setupUser changes the groups, gid, and uid for the user inside the container
 func setupUser(config *initConfig) error {
 	// Set up defaults.

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -817,5 +818,98 @@ func TestSeccompNoChown(t *testing.T) {
 	}
 	if s := buffers.String(); !strings.Contains(s, "not permitted") {
 		t.Fatalf("running chown should result in an EPERM but got %q", s)
+	}
+}
+
+func TestInitJoinPID(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs)
+
+	// Execute a long-running container
+	container1, err := newContainer(newTemplateConfig(rootfs))
+	ok(t, err)
+	defer container1.Destroy()
+
+	stdinR1, stdinW1, err := os.Pipe()
+	ok(t, err)
+	init1 := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR1,
+	}
+	err = container1.Start(init1)
+	stdinR1.Close()
+	defer stdinW1.Close()
+	ok(t, err)
+
+	// get the state of the first container
+	state1, err := container1.State()
+	ok(t, err)
+	pidns1 := state1.NamespacePaths[configs.NEWPID]
+
+	// Execute another container inside the existing pid ns but with a
+	// different cgroups
+	config2 := newTemplateConfig(rootfs)
+	config2.Namespaces.Add(configs.NEWPID, pidns1)
+	config2.Cgroups.Name = "test2"
+	container2, err := newContainerName("testCT2", config2)
+	ok(t, err)
+	defer container2.Destroy()
+
+	stdinR2, stdinW2, err := os.Pipe()
+	ok(t, err)
+	init2 := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR2,
+	}
+	err = container2.Start(init2)
+	stdinR2.Close()
+	defer stdinW2.Close()
+	ok(t, err)
+	// get the state of the second container
+	state2, err := container2.State()
+	ok(t, err)
+
+	// check that pidns is the same
+	if state2.NamespacePaths[configs.NEWPID] != state1.NamespacePaths[configs.NEWPID] {
+		t.Errorf("Pidns(%q), wanted %s", state2.NamespacePaths[configs.NEWPID],
+			state1.NamespacePaths[configs.NEWPID])
+	}
+	// check that namespaces are not the same
+	if reflect.DeepEqual(state2.NamespacePaths, state1.NamespacePaths) {
+		t.Errorf("Namespaces(%v), original %v", state2.NamespacePaths,
+			state1.NamespacePaths)
+	}
+	// check that pidns is joined correctly. The initial container process list
+	// should contain the second container's init process
+	buffers := newStdBuffers()
+	ps := &libcontainer.Process{
+		Args:   []string{"ps"},
+		Env:    standardEnvironment,
+		Stdout: buffers.Stdout,
+	}
+	err = container1.Start(ps)
+	ok(t, err)
+	waitProcess(ps, t)
+
+	// Stop init processes one by one. Stop the second container should
+	// not stop the first.
+	stdinW2.Close()
+	waitProcess(init2, t)
+	stdinW1.Close()
+	waitProcess(init1, t)
+
+	out := strings.TrimSpace(buffers.Stdout.String())
+	// output of ps inside the initial PID namespace should have
+	// 1 line of header,
+	// 2 lines of init processes,
+	// 1 line of ps process
+	if len(strings.Split(out, "\n")) != 4 {
+		t.Errorf("unexpected running process, output %q", out)
 	}
 }

--- a/libcontainer/integration/exec_test.go
+++ b/libcontainer/integration/exec_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -875,11 +876,16 @@ func TestInitJoinPID(t *testing.T) {
 	state2, err := container2.State()
 	ok(t, err)
 
-	// check that pidns is the same
-	if state2.NamespacePaths[configs.NEWPID] != state1.NamespacePaths[configs.NEWPID] {
-		t.Errorf("Pidns(%q), wanted %s", state2.NamespacePaths[configs.NEWPID],
-			state1.NamespacePaths[configs.NEWPID])
+	for _, ns := range []string{"pid"} {
+		ns1, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", state1.InitProcessPid, ns))
+		ok(t, err)
+		ns2, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", state2.InitProcessPid, ns))
+		ok(t, err)
+		if ns1 != ns2 {
+			t.Errorf("%s(%s), wanted %s", ns, ns2, ns1)
+		}
 	}
+
 	// check that namespaces are not the same
 	if reflect.DeepEqual(state2.NamespacePaths, state1.NamespacePaths) {
 		t.Errorf("Namespaces(%v), original %v", state2.NamespacePaths,

--- a/libcontainer/integration/execin_test.go
+++ b/libcontainer/integration/execin_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/configs"
 )
 
 func TestExecIn(t *testing.T) {
@@ -330,5 +332,61 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	out2 := string(buf)
 	if out2 != "2" {
 		t.Fatalf("expected second pipe to receive '2', got '%s'", out2)
+	}
+}
+
+func TestExecInUserns(t *testing.T) {
+	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
+		t.Skip("userns is unsupported")
+	}
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs)
+	config := newTemplateConfig(rootfs)
+	config.UidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
+	container, err := newContainer(config)
+	ok(t, err)
+	defer container.Destroy()
+
+	// Execute a first process in the container
+	stdinR, stdinW, err := os.Pipe()
+	ok(t, err)
+	process := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR,
+	}
+	err = container.Start(process)
+	stdinR.Close()
+	defer stdinW.Close()
+	ok(t, err)
+
+	initPID, err := process.Pid()
+	ok(t, err)
+	initUserns, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/user", initPID))
+	ok(t, err)
+
+	buffers := newStdBuffers()
+	process2 := &libcontainer.Process{
+		Args: []string{"readlink", "/proc/self/ns/user"},
+		Env: []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		},
+		Stdout: buffers.Stdout,
+		Stderr: buffers.Stderr,
+	}
+	err = container.Start(process2)
+	ok(t, err)
+	waitProcess(process2, t)
+	stdinW.Close()
+	waitProcess(process, t)
+
+	if out := strings.TrimSpace(buffers.Stdout.String()); out != initUserns {
+		t.Errorf("execin userns(%s), wanted %s", out, initUserns)
 	}
 }

--- a/libcontainer/integration/utils_test.go
+++ b/libcontainer/integration/utils_test.go
@@ -92,13 +92,15 @@ func copyBusybox(dest string) error {
 }
 
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	f := factory
+	return newContainerName("testCT", config)
+}
 
+func newContainerName(name string, config *configs.Config) (libcontainer.Container, error) {
+	f := factory
 	if config.Cgroups != nil && config.Cgroups.Slice == "system.slice" {
 		f = systemdFactory
 	}
-
-	return f.Create("testCT", config)
+	return f.Create(name, config)
 }
 
 // runContainer runs the container with the specific config and arguments

--- a/libcontainer/process.go
+++ b/libcontainer/process.go
@@ -11,6 +11,7 @@ type processOperations interface {
 	wait() (*os.ProcessState, error)
 	signal(sig os.Signal) error
 	pid() int
+	chldDisabled() bool
 }
 
 // Process specifies the configuration and IO for a process inside
@@ -49,6 +50,14 @@ type Process struct {
 	Capabilities []string
 
 	ops processOperations
+}
+
+// Check if the process has disabled SIGCHLD handling
+func (p Process) ChldDisabled() bool {
+	if p.ops == nil {
+		return false
+	}
+	return p.ops.chldDisabled()
 }
 
 // Wait waits for the process to exit.

--- a/libcontainer/process_linux.go
+++ b/libcontainer/process_linux.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
 )
 
@@ -165,6 +166,11 @@ type initProcess struct {
 	manager    cgroups.Manager
 	container  *linuxContainer
 	fds        []string
+
+	// joinNamespaces are additional namespaces that the init process will join
+	// instead of creating new ones
+	joinNamespaces configs.Namespaces
+	doClone        bool
 }
 
 func (p *initProcess) pid() int {
@@ -175,12 +181,46 @@ func (p *initProcess) externalDescriptors() []string {
 	return p.fds
 }
 
+// execSetns runs the process that executes C code to perform the setns calls
+// because setns support requires the C process to fork off a child and perform the setns
+// before the go runtime boots, we wait on the process to die and receive the child's pid
+// over the provided pipe.
+// This is called by initProcess.start function
+func (p *initProcess) execSetns() error {
+	status, err := p.cmd.Process.Wait()
+	if err != nil {
+		p.cmd.Wait()
+		return err
+	}
+	if !status.Success() {
+		p.cmd.Wait()
+		return &exec.ExitError{ProcessState: status}
+	}
+	var pid *pid
+	if err := json.NewDecoder(p.parentPipe).Decode(&pid); err != nil {
+		p.cmd.Wait()
+		return err
+	}
+	process, err := os.FindProcess(pid.Pid)
+	if err != nil {
+		return err
+	}
+	p.cmd.Process = process
+	return nil
+}
+
 func (p *initProcess) start() error {
 	defer p.parentPipe.Close()
 	err := p.cmd.Start()
 	p.childPipe.Close()
 	if err != nil {
 		return newSystemError(err)
+	}
+	// if we need to clone a new child process
+	if len(p.joinNamespaces) > 0 && p.doClone {
+		if err := p.execSetns(); err != nil {
+			return newSystemError(err)
+		}
 	}
 	// Save the standard descriptor names before the container process
 	// can potentially move them (e.g., via dup2()).  If we don't do this now,

--- a/libcontainer/restored_process.go
+++ b/libcontainer/restored_process.go
@@ -76,6 +76,10 @@ func (p *restoredProcess) setExternalDescriptors(newFds []string) {
 	p.fds = newFds
 }
 
+func (p *restoredProcess) chldDisabled() bool {
+	return false
+}
+
 // nonChildProcess represents a process where the calling process is not
 // the parent process.  This process is created when a factory loads a container from
 // a persisted state.
@@ -115,4 +119,8 @@ func (p *nonChildProcess) externalDescriptors() []string {
 
 func (p *nonChildProcess) setExternalDescriptors(newFds []string) {
 	p.fds = newFds
+}
+
+func (p *nonChildProcess) chldDisabled() bool {
+	return false
 }

--- a/libcontainer/standard_init_linux.go
+++ b/libcontainer/standard_init_linux.go
@@ -18,10 +18,6 @@ type linuxStandardInit struct {
 }
 
 func (l *linuxStandardInit) Init() error {
-	// join any namespaces via a path to the namespace fd if provided
-	if err := joinExistingNamespaces(l.config.Config.Namespaces); err != nil {
-		return err
-	}
 	var console *linuxConsole
 	if l.config.Console != "" {
 		console = newConsoleFromPath(l.config.Console)

--- a/signals.go
+++ b/signals.go
@@ -56,6 +56,9 @@ func (h *signalHandler) forward(process *libcontainer.Process) (int, error) {
 		case syscall.SIGWINCH:
 			h.tty.resize()
 		case syscall.SIGCHLD:
+			if process.ChldDisabled() {
+				continue
+			}
 			exits, err := h.reap()
 			if err != nil {
 				logrus.Error(err)

--- a/spec.go
+++ b/spec.go
@@ -300,7 +300,6 @@ func setupUserNamespace(spec *specs.LinuxSpec, config *configs.Config) error {
 	if len(spec.Linux.UidMappings) == 0 {
 		return nil
 	}
-	config.Namespaces.Add(configs.NEWUSER, "")
 	create := func(m specs.IDMapping) configs.IDMap {
 		return configs.IDMap{
 			ContainerID: int(m.From),


### PR DESCRIPTION
There are 3 commits here.

The first removes cloneflags from initProcess
the second makes sure that the SIGCHLD from the fork gets ignored
the third refactors out setnsProcess

The sigchild handling is necessary because we replace the pid of the Cmd.Process when the fork happens. This causes the wait for cleanup to busy loop. There is another option for the sigchld handling: We could replace the handler when we spawn the process and instead of just waiting until the process exits, we could wait for the SIGCHILD to be handled, and then replace the process pid with the new one. It is probably a little more accurate to do it that way, but it is also more complex.
